### PR TITLE
Form velden genereren relations

### DIFF
--- a/plugins/essif-lab/src/Constants.php
+++ b/plugins/essif-lab/src/Constants.php
@@ -32,6 +32,7 @@ abstract class Constants {
 	const TYPE_DEFAULT_ATTRIBUTE_NAMES = [
 		self::TYPE_INSTANCE_IDENTIFIER_ATTR,
 		self::TYPE_INSTANCE_TITLE_ATTR,
+        self::TYPE_INSTANCE_DESCRIPTION_ATTR,
 	];
 
 	const TYPE_DEFAULT_FIELDS = [

--- a/plugins/essif-lab/src/Integrations/Contracts/BaseIntegration.php
+++ b/plugins/essif-lab/src/Integrations/Contracts/BaseIntegration.php
@@ -10,10 +10,6 @@ use TNO\EssifLab\Models\Contracts\Model;
 use TNO\EssifLab\Utilities\Contracts\Utility;
 
 abstract class BaseIntegration implements Integration {
-	public const GET_ADD_TYPE_LINK = 'get_add_type_link';
-
-	public const GET_EDIT_TYPE_LINK = 'get_edit_type_link';
-
 	protected $application;
 
 	protected $manager;

--- a/plugins/essif-lab/src/Integrations/Contracts/BaseIntegration.php
+++ b/plugins/essif-lab/src/Integrations/Contracts/BaseIntegration.php
@@ -6,6 +6,7 @@ use HaydenPierce\ClassFinder\ClassFinder;
 use TNO\EssifLab\Applications\Contracts\Application;
 use TNO\EssifLab\Constants;
 use TNO\EssifLab\ModelManagers\Contracts\ModelManager;
+use TNO\EssifLab\ModelRenderers\Contracts\ModelRenderer;
 use TNO\EssifLab\Models\Contracts\Model;
 use TNO\EssifLab\Utilities\Contracts\Utility;
 
@@ -14,11 +15,14 @@ abstract class BaseIntegration implements Integration {
 
 	protected $manager;
 
+	protected $renderer;
+
 	protected $utility;
 
-	function __construct(Application $application, ModelManager $manager, Utility $utility) {
+	function __construct(Application $application, ModelManager $manager, ModelRenderer $renderer, Utility $utility) {
 		$this->application = $application;
 		$this->manager = $manager;
+		$this->renderer = $renderer;
 		$this->utility = $utility;
 	}
 

--- a/plugins/essif-lab/src/Integrations/Contracts/Integration.php
+++ b/plugins/essif-lab/src/Integrations/Contracts/Integration.php
@@ -4,17 +4,13 @@ namespace TNO\EssifLab\Integrations\Contracts;
 
 use TNO\EssifLab\Applications\Contracts\Application;
 use TNO\EssifLab\ModelManagers\Contracts\ModelManager;
-use TNO\EssifLab\Models\Contracts\Model;
+use TNO\EssifLab\ModelRenderers\Contracts\ModelRenderer;
 use TNO\EssifLab\Utilities\Contracts\Utility;
 
 interface Integration {
-	function __construct(Application $application, ModelManager $manager, Utility $utility);
+	function __construct(Application $application, ModelManager $manager,ModelRenderer $renderer, Utility $utility);
 
 	function install(): void;
-
-	function registerModelType(Model $model): void;
-
-	function registerModelRelations(Model $model): void;
 
 	function getApplication(): Application;
 

--- a/plugins/essif-lab/src/Integrations/WordPress.php
+++ b/plugins/essif-lab/src/Integrations/WordPress.php
@@ -18,7 +18,7 @@ class WordPress extends BaseIntegration {
 
 	function install(): void {
 		$this->utility->call(WP::ADD_ACTION, 'admin_menu', [$this, 'registerAdminMenu']);
-		$this->utility->call(WP::ADD_ACTION, 'init', [$this, 'registerPostTypes']);
+		$this->utility->call(WP::ADD_ACTION, 'init', [$this, 'registerModelTypes']);
 		$this->registerMetaBoxes();
 	}
 
@@ -30,7 +30,7 @@ class WordPress extends BaseIntegration {
 		$this->utility->call(WP::ADD_NAV_ITEM, $title, $capability, $slug, $icon);
 	}
 
-	function registerPostTypes(): void {
+	function registerModelTypes(): void {
 		BaseIntegration::forAllModels(function (Model $instance) {
 			$this->registerModelType($instance);
 		});

--- a/plugins/essif-lab/src/Integrations/WordPress.php
+++ b/plugins/essif-lab/src/Integrations/WordPress.php
@@ -65,12 +65,8 @@ class WordPress extends BaseIntegration {
 	}
 
 	function renderModelRelation(Model $parent, Model $related): string {
-	    $relatedModelInstances = $this->manager->select($related);
-	    $formItems = array_map(function(Model $relatedModelInstance) {
-	        $attr = $relatedModelInstance->getAttributes();
-	        return new Displayable($attr[Constants::TYPE_INSTANCE_IDENTIFIER_ATTR], $attr[Constants::TYPE_INSTANCE_TITLE_ATTR]);
-        }, $relatedModelInstances);
-        $listItems = [];
+        $formItems = $this->generateFormItems($related);
+        $listItems = $this->generateListItems($parent);
 		$values = [
 			new MultiDimensional($formItems, TypeList::FORM_ITEMS),
 			new MultiDimensional($listItems, TypeList::LIST_ITEMS),
@@ -134,4 +130,32 @@ class WordPress extends BaseIntegration {
 
 		return array_merge($default, $args);
 	}
+
+    /**
+     * @param Model $related
+     * @return array
+     */
+    public function generateFormItems(Model $related): array
+    {
+        return array_map(function (Model $model) {
+            $attr = $model->getAttributes();
+            $ID = $attr[Constants::TYPE_INSTANCE_IDENTIFIER_ATTR];
+            return new Displayable($ID, $attr[Constants::TYPE_INSTANCE_TITLE_ATTR]);
+        }, $this->manager->select($related));
+    }
+
+    /**
+     * @param Model $parent
+     * @return array
+     */
+    public function generateListItems(Model $parent): array
+    {
+        return array_map(function (Model $model) {
+            $attr = $model->getAttributes();
+            $ID = $attr[Constants::TYPE_INSTANCE_IDENTIFIER_ATTR];
+            $title = new Displayable($ID, $attr[Constants::TYPE_INSTANCE_TITLE_ATTR]);
+            $description = new Displayable($ID, $attr[Constants::TYPE_INSTANCE_DESCRIPTION_ATTR]);
+            return new MultiDimensional([$title, $description]);
+        }, $this->manager->selectAllRelations($parent));
+    }
 }

--- a/plugins/essif-lab/src/Integrations/WordPress.php
+++ b/plugins/essif-lab/src/Integrations/WordPress.php
@@ -7,6 +7,7 @@ use TNO\EssifLab\Integrations\Contracts\BaseIntegration;
 use TNO\EssifLab\Models\Contracts\Model;
 use TNO\EssifLab\Utilities\Contracts\BaseUtility;
 use TNO\EssifLab\Utilities\WordPress as WP;
+use TNO\EssifLab\Views\Items\Displayable;
 use TNO\EssifLab\Views\Items\MultiDimensional;
 use TNO\EssifLab\Views\TypeList;
 
@@ -64,9 +65,15 @@ class WordPress extends BaseIntegration {
 	}
 
 	function renderModelRelation(Model $parent, Model $related): string {
+	    $relatedModelInstances = $this->manager->select($related);
+	    $formItems = array_map(function(Model $relatedModelInstance) {
+	        $attr = $relatedModelInstance->getAttributes();
+	        return new Displayable($attr[Constants::TYPE_INSTANCE_IDENTIFIER_ATTR], $attr[Constants::TYPE_INSTANCE_TITLE_ATTR]);
+        }, $relatedModelInstances);
+        $listItems = [];
 		$values = [
-			new MultiDimensional([], TypeList::FORM_ITEMS),
-			new MultiDimensional([], TypeList::LIST_ITEMS),
+			new MultiDimensional($formItems, TypeList::FORM_ITEMS),
+			new MultiDimensional($listItems, TypeList::LIST_ITEMS),
 		];
 
 		return $this->renderer->renderListAndFormView($this, $related, $values);

--- a/plugins/essif-lab/src/Integrations/WordPress.php
+++ b/plugins/essif-lab/src/Integrations/WordPress.php
@@ -69,7 +69,7 @@ class WordPress extends BaseIntegration {
 			new MultiDimensional([], TypeList::LIST_ITEMS),
 		];
 
-		return (new TypeList($this, $related, $values))->render();
+		return $this->renderer->renderListAndFormView($this, $related, $values);
 	}
 
 	static function getAddTypeLink(string $postType) {

--- a/plugins/essif-lab/src/ModelManagers/WordPressPostTypes.php
+++ b/plugins/essif-lab/src/ModelManagers/WordPressPostTypes.php
@@ -5,12 +5,10 @@ namespace TNO\EssifLab\ModelManagers;
 use TNO\EssifLab\Applications\Contracts\Application;
 use TNO\EssifLab\Constants;
 use TNO\EssifLab\ModelManagers\Contracts\BaseModelManager;
-use TNO\EssifLab\ModelManagers\Exceptions\InvalidModelType;
 use TNO\EssifLab\ModelManagers\Exceptions\MissingIdentifier;
 use TNO\EssifLab\Models\Contracts\Model;
 use TNO\EssifLab\Utilities\Contracts\BaseUtility;
 use TNO\EssifLab\Utilities\Contracts\Utility;
-use WP_Post;
 
 class WordPressPostTypes extends BaseModelManager {
 	private $relationKey;
@@ -25,7 +23,7 @@ class WordPressPostTypes extends BaseModelManager {
 	}
 
 	function update(Model $model): bool {
-		if (self::getModelIdentifier($model) < 0) {
+		if (self::getModelId($model) < 0) {
 			throw new MissingIdentifier($model->getSingularName());
 		}
 
@@ -36,16 +34,13 @@ class WordPressPostTypes extends BaseModelManager {
 		$args = array_merge([
 			Constants::MANAGER_TYPE_ID_CRITERIA_NAME => $model->getTypeName(),
 		], $criteria);
-		$posts = $this->utility->call(BaseUtility::GET_MODELS, $args);
 
-		return self::postsToModels($posts);
+		return $this->utility->call(BaseUtility::GET_MODELS, $args);
 	}
 
 	function delete(Model $model): bool {
-		$id = $this->getModelIdentifier($model);
-		if ($id < 0) {
-			throw new MissingIdentifier($model->getSingularName());
-		}
+		$id = $this->getGivenOrCurrentModelId($model);
+
 		$result = $this->utility->call(BaseUtility::DELETE_MODEL, $id);
 
 		$this->deleteAllRelations($model);
@@ -54,12 +49,8 @@ class WordPressPostTypes extends BaseModelManager {
 	}
 
 	function insertRelation(Model $from, Model $to): bool {
-		$fromId = $this->getModelIdentifier($from);
-		$toId = $this->getModelIdentifier($to);
-
-		if ($fromId < 0) {
-			throw new MissingIdentifier($from->getSingularName());
-		}
+		$fromId = $this->getGivenOrCurrentModelId($from);
+		$toId = $this->getModelId($to);
 
 		if ($toId < 0) {
 			throw new MissingIdentifier($to->getSingularName());
@@ -72,12 +63,8 @@ class WordPressPostTypes extends BaseModelManager {
 	}
 
 	function deleteRelation(Model $from, Model $to): bool {
-		$fromId = $this->getModelIdentifier($from);
-		$toId = $this->getModelIdentifier($to);
-
-		if ($fromId < 0) {
-			throw new MissingIdentifier($from->getSingularName());
-		}
+		$fromId = $this->getGivenOrCurrentModelId($from);
+		$toId = $this->getModelId($to);
 
 		if ($toId < 0) {
 			throw new MissingIdentifier($to->getSingularName());
@@ -90,11 +77,7 @@ class WordPressPostTypes extends BaseModelManager {
 	}
 
 	function deleteAllRelations(Model $model): bool {
-		$id = $this->getModelIdentifier($model);
-
-		if ($id < 0) {
-			throw new MissingIdentifier($model->getSingularName());
-		}
+		$id = $this->getGivenOrCurrentModelId($model);
 
 		$relationIds = get_post_meta($id, $this->relationKey);
 		foreach ($relationIds as $relationId) {
@@ -105,73 +88,40 @@ class WordPressPostTypes extends BaseModelManager {
 	}
 
 	function selectAllRelations(Model $model): array {
-		$id = $this->getModelIdentifier($model);
-
-		if ($id < 0) {
-			throw new MissingIdentifier($model->getSingularName());
-		}
+		$id = $this->getGivenOrCurrentModelId($model);
 
 		$relationIds = $this->utility->call(BaseUtility::GET_MODEL_META, $id, $this->relationKey);
 
 		$args = array_merge(Constants::TYPE_DEFAULT_TYPE_ARGS, [
-			'post_type' => 'any',
 			'post__in' => $relationIds,
 		]);
-		$posts = $this->utility->call(BaseUtility::GET_MODELS, $args);
 
-		return self::postsToModels($posts);
+		return empty($relationIds) ?  [] : $this->utility->call(BaseUtility::GET_MODELS, $args);
 	}
 
-	private static function getModelIdentifier(Model $model): int {
+	private function getGivenOrCurrentModelId(Model $model): int {
+		$id = $this->getModelId($model);
+
+		if ($id > 0) {
+			return $id;
+		}
+
+		$currentModel = $this->utility->call(BaseUtility::GET_CURRENT_MODEL);
+		$isArray = is_array($currentModel);
+		$hasTypeKey = $isArray && array_key_exists(Constants::MANAGER_TYPE_ID_CRITERIA_NAME, $currentModel);
+		$isSameType = $hasTypeKey && $currentModel[Constants::MANAGER_TYPE_ID_CRITERIA_NAME] === $model->getTypeName();
+		$hasIdKey = $isArray && array_key_exists(Constants::TYPE_INSTANCE_IDENTIFIER_ATTR, $currentModel);
+		if ($isSameType && $hasIdKey) {
+			return $currentModel[Constants::TYPE_INSTANCE_IDENTIFIER_ATTR];
+		}
+
+		throw new MissingIdentifier($model->getSingularName());
+	}
+
+	private static function getModelId(Model $model): int {
 		$attributes = $model->getAttributes();
 		$idKey = Constants::TYPE_INSTANCE_IDENTIFIER_ATTR;
 
 		return array_key_exists($idKey, $attributes) && intval($attributes[$idKey]) !== 0 ? intval($attributes[$idKey]) : -1;
-	}
-
-	private static function postsToModels(array $posts): array {
-		return array_map(function (WP_Post $post) {
-			return self::modelFactory($post->to_array());
-		}, $posts);
-	}
-
-	private static function modelFactory(array $args): Model {
-		$type = array_key_exists(Constants::MANAGER_TYPE_ID_CRITERIA_NAME, $args) ? $args[Constants::MANAGER_TYPE_ID_CRITERIA_NAME] : '';
-
-		$className = implode('', array_map('ucfirst', explode(' ', str_replace('-', ' ', $type))));
-		$FQN = Constants::TYPE_NAMESPACE.'\\'.$className;
-
-		if (empty($type) || ! class_exists($FQN) || ! in_array(Model::class, class_implements($FQN))) {
-			throw new InvalidModelType($FQN);
-		}
-
-		$attrs = self::extractAttributesFromArgs($args);
-
-		return new $FQN($attrs);
-	}
-
-	private static function extractAttributesFromArgs(array $args): array {
-		$id = array_key_exists(Constants::TYPE_INSTANCE_IDENTIFIER_ATTR, $args) ? $args[Constants::TYPE_INSTANCE_IDENTIFIER_ATTR] : 0;
-		$title = array_key_exists('post_title', $args) ? $args['post_title'] : '';
-		$content = array_key_exists('post_content', $args) ? $args['post_content'] : '';
-		$contentToJson = self::jsonStringToAssocArray($content);
-		$description = empty($contentToJson) ? $content : '';
-
-		return array_filter(array_merge($contentToJson, [
-			Constants::TYPE_INSTANCE_IDENTIFIER_ATTR => $id,
-			Constants::TYPE_INSTANCE_TITLE_ATTR => $title,
-			Constants::TYPE_INSTANCE_DESCRIPTION_ATTR => $description,
-		]));
-	}
-
-	private static function jsonStringToAssocArray(string $string): array {
-		$json = json_decode($string);
-		$isValidJson = json_last_error() === JSON_ERROR_NONE;
-		$isAssocArray = is_array($json) && array_keys($json) !== range(0, count($json) - 1);
-		if ($isValidJson && $isAssocArray) {
-			return $json;
-		}
-
-		return [];
 	}
 }

--- a/plugins/essif-lab/src/ModelRenderers/Contracts/ModelRenderer.php
+++ b/plugins/essif-lab/src/ModelRenderers/Contracts/ModelRenderer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace TNO\EssifLab\ModelRenderers\Contracts;
+
+use TNO\EssifLab\Integrations\Contracts\Integration;
+use TNO\EssifLab\Models\Contracts\Model;
+
+interface ModelRenderer {
+	function renderListAndFormView(Integration $integration, Model $model, array $attrs = []): string;
+}

--- a/plugins/essif-lab/src/ModelRenderers/WordPressMetaBox.php
+++ b/plugins/essif-lab/src/ModelRenderers/WordPressMetaBox.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace TNO\EssifLab\ModelRenderers;
+
+use TNO\EssifLab\Integrations\Contracts\Integration;
+use TNO\EssifLab\Models\Contracts\Model;
+use TNO\EssifLab\Views\TypeList;
+
+class WordPressMetaBox implements Contracts\ModelRenderer {
+	function renderListAndFormView(Integration $integration, Model $model, array $attrs = []): string {
+		$view = new TypeList($integration, $model, $attrs);
+		return $view->render();
+	}
+}

--- a/plugins/essif-lab/src/Models/Contracts/BaseModel.php
+++ b/plugins/essif-lab/src/Models/Contracts/BaseModel.php
@@ -47,32 +47,32 @@ abstract class BaseModel implements Model {
 	}
 
 	public function getTypeArgs(): array {
-		return array_merge(Constants::TYPE_DEFAULT_TYPE_ARGS, self::parseArray($this->typeArgs));
+		return array_merge(Constants::TYPE_DEFAULT_TYPE_ARGS, self::isArray($this->typeArgs));
 	}
 
 	public function getAttributes(): array {
-		return self::parseArray($this->attributes);
+		return self::isArray($this->attributes);
 	}
 
 	public function setAttributes($value): void {
-		$this->attributes = array_filter(self::parseArray($value), function ($key) {
+		$this->attributes = array_filter(self::isArray($value), function ($key) {
 			return in_array($key, $this->getAttributeNames());
 		}, ARRAY_FILTER_USE_KEY);
 	}
 
 	public function getAttributeNames(): array {
-		return array_merge(Constants::TYPE_DEFAULT_ATTRIBUTE_NAMES, self::parseArray($this->attributeNames));
+		return array_merge(Constants::TYPE_DEFAULT_ATTRIBUTE_NAMES, self::isArray($this->attributeNames));
 	}
 
 	public function getFields(): array {
-		return array_merge(Constants::TYPE_DEFAULT_FIELDS, self::parseArray($this->fields));
+		return array_merge(Constants::TYPE_DEFAULT_FIELDS, self::isArray($this->fields));
 	}
 
 	public function getRelations(): array {
-		return self::parseArray($this->relations);
+		return self::isArray($this->relations);
 	}
 
-	private static function parseArray($value): array {
+	private static function isArray($value): array {
 		return is_array($value) ? $value : [];
 	}
 }

--- a/plugins/essif-lab/src/Utilities/Contracts/BaseUtility.php
+++ b/plugins/essif-lab/src/Utilities/Contracts/BaseUtility.php
@@ -9,6 +9,8 @@ abstract class BaseUtility implements Utility {
 
 	public const GET_MODELS = 'getModels';
 
+	public const GET_CURRENT_MODEL = 'getCurrentModel';
+
 	public const DELETE_MODEL = 'deleteModel';
 
 	public const CREATE_MODEL_TYPE = 'createModelType';
@@ -31,6 +33,7 @@ abstract class BaseUtility implements Utility {
 			self::CREATE_MODEL => [static::class, 'createModel'],
 			self::DELETE_MODEL => [static::class, 'deleteModel'],
 			self::GET_MODELS => [static::class, 'getModels'],
+			self::GET_CURRENT_MODEL => [static::class, 'getCurrentModel'],
 			self::CREATE_MODEL_META => [static::class, 'createModelMeta'],
 			self::DELETE_MODEL_META => [static::class, 'deleteModelMeta'],
 			self::GET_MODEL_META => [static::class, 'getModelMeta'],

--- a/plugins/essif-lab/src/Utilities/Exceptions/InvalidModelType.php
+++ b/plugins/essif-lab/src/Utilities/Exceptions/InvalidModelType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TNO\EssifLab\ModelManagers\Exceptions;
+namespace TNO\EssifLab\Utilities\Exceptions;
 
 use Throwable;
 use Exception;

--- a/plugins/essif-lab/src/Utilities/WordPress.php
+++ b/plugins/essif-lab/src/Utilities/WordPress.php
@@ -2,7 +2,10 @@
 
 namespace TNO\EssifLab\Utilities;
 
+use TNO\EssifLab\Constants;
+use TNO\EssifLab\Models\Contracts\Model;
 use TNO\EssifLab\Utilities\Contracts\BaseUtility;
+use TNO\EssifLab\Utilities\Exceptions\InvalidModelType;
 
 class WordPress extends BaseUtility {
 	const ADD_ACTION = 'add_action';
@@ -23,7 +26,7 @@ class WordPress extends BaseUtility {
 		self::DO_ACTION => [self::class, 'doAction'],
 		self::APPLY_FILTERS => [self::class, 'applyFilter'],
 		self::ADD_META_BOX => [self::class, 'addMetaBox'],
-		self::ADD_NAV_ITEM =>  [self::class, 'addAdminNav'],
+		self::ADD_NAV_ITEM => [self::class, 'addAdminNav'],
 	];
 
 	static function addAction(string $hook, callable $callback, int $priority = 10, int $accepted_args = 1): void {
@@ -42,7 +45,7 @@ class WordPress extends BaseUtility {
 		return apply_filters($tag, $value, ...$params);
 	}
 
-	static function addMetaBox(string $id, string $title, callable $callback, string $screen):void {
+	static function addMetaBox(string $id, string $title, callable $callback, string $screen): void {
 		add_meta_box($id, $title, $callback, $screen, 'normal');
 	}
 
@@ -56,7 +59,7 @@ class WordPress extends BaseUtility {
 
 	static function createModel(array $args): bool {
 		$result = wp_insert_post($args, true);
-		if (!is_int($result)) {
+		if (! is_int($result)) {
 			throw $result;
 		}
 
@@ -68,10 +71,58 @@ class WordPress extends BaseUtility {
 	}
 
 	static function getModels(array $args = []): array {
-		return get_posts(array_merge([
+		return array_map(function ($post) {
+			return self::modelFactory($post->to_array());
+		}, get_posts(array_merge([
 			'numberposts' => -1,
 			'post_type' => 'any',
-		], $args));
+		], $args)));
+	}
+
+	private static function modelFactory(array $args): Model {
+		$type = array_key_exists(Constants::MANAGER_TYPE_ID_CRITERIA_NAME, $args) ? $args[Constants::MANAGER_TYPE_ID_CRITERIA_NAME] : '';
+
+		$className = implode('', array_map('ucfirst', explode(' ', str_replace('-', ' ', $type))));
+		$FQN = Constants::TYPE_NAMESPACE.'\\'.$className;
+
+		if (empty($type) || ! class_exists($FQN) || ! in_array(Model::class, class_implements($FQN))) {
+			throw new InvalidModelType($FQN);
+		}
+
+		$attrs = self::extractAttributesFromArgs($args);
+
+		return new $FQN($attrs);
+	}
+
+	private static function extractAttributesFromArgs(array $args): array {
+		$id = array_key_exists(Constants::TYPE_INSTANCE_IDENTIFIER_ATTR, $args) ? $args[Constants::TYPE_INSTANCE_IDENTIFIER_ATTR] : 0;
+		$title = array_key_exists('post_title', $args) ? $args['post_title'] : '';
+		$content = array_key_exists('post_content', $args) ? $args['post_content'] : '';
+		$contentToJson = self::jsonStringToAssocArray($content);
+		$description = empty($contentToJson) ? $content : '';
+
+		return array_filter(array_merge($contentToJson, [
+			Constants::TYPE_INSTANCE_IDENTIFIER_ATTR => $id,
+			Constants::TYPE_INSTANCE_TITLE_ATTR => $title,
+			Constants::TYPE_INSTANCE_DESCRIPTION_ATTR => $description,
+		]));
+	}
+
+	private static function jsonStringToAssocArray(string $string): array {
+		$json = json_decode($string);
+		$isValidJson = json_last_error() === JSON_ERROR_NONE;
+		$isAssocArray = is_array($json) && array_keys($json) !== range(0, count($json) - 1);
+		if ($isValidJson && $isAssocArray) {
+			return $json;
+		}
+
+		return [];
+	}
+
+	static function getCurrentModel(): array {
+		global $post;
+
+		return $post->to_array();
 	}
 
 	static function createModelMeta(int $postId, string $key, $value): bool {

--- a/plugins/essif-lab/src/Views/ListForm.php
+++ b/plugins/essif-lab/src/Views/ListForm.php
@@ -3,6 +3,7 @@
 namespace TNO\EssifLab\Views;
 
 use TNO\EssifLab\Integrations\Contracts\BaseIntegration;
+use TNO\EssifLab\Utilities\Contracts\BaseUtility;
 use TNO\EssifLab\Views\Contracts\BaseView;
 
 class ListForm extends BaseView {
@@ -27,7 +28,7 @@ class ListForm extends BaseView {
 	}
 
 	private function renderAddNewButton(): string {
-		$url = $this->integration->getUtility()->call(BaseIntegration::GET_ADD_TYPE_LINK, $this->model->getTypeName());
+		$url = $this->integration->getUtility()->call(BaseUtility::GET_CREATE_MODEL_LINK, $this->model->getTypeName());
 		$message = sprintf(self::ADD_NEW, ucfirst($this->model->getSingularName()));
 
 		return '<a href="'.$url.'" class="button btn">'.$message.'</a>';

--- a/plugins/essif-lab/src/Views/ListItemForm.php
+++ b/plugins/essif-lab/src/Views/ListItemForm.php
@@ -4,6 +4,7 @@ namespace TNO\EssifLab\Views;
 
 use TNO\EssifLab\Constants;
 use TNO\EssifLab\Integrations\Contracts\BaseIntegration;
+use TNO\EssifLab\Utilities\Contracts\BaseUtility;
 use TNO\EssifLab\Views\Contracts\BaseView;
 use TNO\EssifLab\Views\Items\Contracts\Item;
 
@@ -30,7 +31,7 @@ class ListItemForm extends BaseView {
 	}
 
 	private function renderEdit(Item $item) {
-		$url = $this->integration->getUtility()->call(BaseIntegration::GET_EDIT_TYPE_LINK, $item->getValue());
+		$url = $this->integration->getUtility()->call(BaseUtility::GET_EDIT_MODEL_LINK, $item->getValue());
 		$title = self::EDIT.' '.$item->getLabel();
 
 		return '<a href="'.$url.'" title="'.$title.'" class="button-link">'.self::EDIT.'</a>';

--- a/plugins/essif-lab/src/Views/TypeList.php
+++ b/plugins/essif-lab/src/Views/TypeList.php
@@ -8,7 +8,7 @@ use TNO\EssifLab\Views\Contracts\BaseView;
 use TNO\EssifLab\Views\Contracts\View;
 use TNO\EssifLab\Views\Items\Contracts\BaseItem;
 
-class TypeList extends BaseView {
+class TypeList extends BaseView  {
 	const FORM_ITEMS = 'form_items';
 
 	const LIST_ITEMS = 'list_items';

--- a/plugins/essif-lab/tests/Integrations/WordPressTest.php
+++ b/plugins/essif-lab/tests/Integrations/WordPressTest.php
@@ -106,11 +106,9 @@ class WordPressTest extends TestCase {
 	function registers_menu_item_when_installing() {
 		$this->subject->install();
 
-		$page_title = $this->application->getName();
-		$menu_title = $page_title;
+		$title = $this->application->getName();
 		$capability = Constants::ADMIN_MENU_CAPABILITY;
 		$menu_slug = $this->application->getNamespace();
-		$callback = null;
 		$icon_url = Constants::ADMIN_MENU_ICON_URL;
 		
 		$history = $this->utility->getHistoryByFuncName(WP::ADD_NAV_ITEM);
@@ -120,11 +118,9 @@ class WordPressTest extends TestCase {
 		$entry = current($history);
 		$params = $entry->getParams();
 		
-		$this->assertEquals($page_title, $params[0]);
-		$this->assertEquals($menu_title, $params[1]);
-		$this->assertEquals($capability, $params[2]);
-		$this->assertEquals($menu_slug, $params[3]);
-		$this->assertEquals($callback, $params[4]);
-		$this->assertEquals($icon_url, $params[5]);
+		$this->assertEquals($title, $params[0]);
+		$this->assertEquals($capability, $params[1]);
+		$this->assertEquals($menu_slug, $params[2]);
+		$this->assertEquals($icon_url, $params[3]);
 	}
 }

--- a/plugins/essif-lab/tests/Integrations/WordPressTest.php
+++ b/plugins/essif-lab/tests/Integrations/WordPressTest.php
@@ -125,21 +125,41 @@ class WordPressTest extends TestCase {
 	}
 
 	/** @test */
-	function can_get_form_items_from_each_model_relation() {
-		$this->subject->install();
+    function can_get_form_items_from_each_model_relation() {
+        $this->subject->install();
 
-		$renderWasCalled = $this->renderer->isRenderListAndFormViewCalled();
-		$this->assertTrue($renderWasCalled);
+        $renderWasCalled = $this->renderer->isRenderListAndFormViewCalled();
+        $this->assertTrue($renderWasCalled);
 
-		$attrs = $this->renderer->getAttrsParamWhereRenderListAndFormViewWasCalledWith();
+        $attrs = $this->renderer->getAttrsParamWhereRenderListAndFormViewWasCalledWith();
 
-		$this->assertNotEmpty($attrs);
-		$this->assertNotEmpty($attrs[0]->getValue());
+        $this->assertNotEmpty($attrs);
+        $this->assertNotEmpty($attrs[0]->getValue());
 
-		// ID of the model
-		$this->assertEquals(1, $attrs[0]->getValue()[0]->getValue());
-		// Title of the model
-		$this->assertEquals('hello', $attrs[0]->getValue()[0]->getLabel());
+        // ID of the model
+        $this->assertEquals(1, $attrs[0]->getValue()[0]->getValue());
+        // Title of the model
+        $this->assertEquals('hello', $attrs[0]->getValue()[0]->getLabel());
+    }
 
-	}
+    /** @test */
+    function can_get_list_items_from_each_model_relation() {
+        $this->subject->install();
+
+        $renderWasCalled = $this->renderer->isRenderListAndFormViewCalled();
+        $this->assertTrue($renderWasCalled);
+
+        $attrs = $this->renderer->getAttrsParamWhereRenderListAndFormViewWasCalledWith();
+
+        $this->assertNotEmpty($attrs);
+        $this->assertNotEmpty($attrs[1]->getValue());
+        $this->assertNotEmpty($attrs[1]->getValue()[0]->getValue());
+
+        //ID of the model
+        $this->assertEquals(1, $attrs[1]->getValue()[0]->getValue()[0]->getValue());
+        //Title of the model
+        $this->assertEquals('hello', $attrs[1]->getValue()[0]->getValue()[0]->getLabel());
+        //Description of the model
+        $this->assertEquals('world', $attrs[1]->getValue()[0]->getValue()[1]->getLabel());
+    }
 }

--- a/plugins/essif-lab/tests/Integrations/WordPressTest.php
+++ b/plugins/essif-lab/tests/Integrations/WordPressTest.php
@@ -14,7 +14,7 @@ class WordPressTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->subject = new WordPress($this->application, $this->manager, $this->utility);
+		$this->subject = new WordPress($this->application, $this->manager, $this->renderer, $this->utility);
 	}
 
 	/** @test */
@@ -122,5 +122,24 @@ class WordPressTest extends TestCase {
 		$this->assertEquals($capability, $params[1]);
 		$this->assertEquals($menu_slug, $params[2]);
 		$this->assertEquals($icon_url, $params[3]);
+	}
+
+	/** @test */
+	function can_get_form_items_from_each_model_relation() {
+		$this->subject->install();
+
+		$renderWasCalled = $this->renderer->isRenderListAndFormViewCalled();
+		$this->assertTrue($renderWasCalled);
+
+		$attrs = $this->renderer->getAttrsParamWhereRenderListAndFormViewWasCalledWith();
+
+		$this->assertNotEmpty($attrs);
+		$this->assertNotEmpty($attrs[0]->getValue());
+
+		// ID of the model
+		$this->assertEquals(1, $attrs[0]->getValue()[0]->getValue());
+		// Title of the model
+		$this->assertEquals('hello', $attrs[0]->getValue()[0]->getLabel());
+
 	}
 }

--- a/plugins/essif-lab/tests/ModelManager/WordPressPostTypesTest.php
+++ b/plugins/essif-lab/tests/ModelManager/WordPressPostTypesTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace TNO\EssifLab\Tests\ModelManager;
+
+use TNO\EssifLab\Constants;
+use TNO\EssifLab\ModelManagers\WordPressPostTypes;
+use TNO\EssifLab\Tests\Stubs\Model;
+use TNO\EssifLab\Tests\TestCase;
+use TNO\EssifLab\Utilities\Contracts\BaseUtility;
+
+class WordPressPostTypesTest extends TestCase {
+	/** @test */
+	function uses_id_of_current_model_if_attribute_is_missing_and_same_type() {
+		$subject = new WordPressPostTypes($this->application, $this->utility);
+		$modelWithoutId = new Model();
+
+		$result = $subject->selectAllRelations($modelWithoutId);
+
+		$history = $this->utility->getHistoryByFuncName(BaseUtility::GET_CURRENT_MODEL);
+		$this->assertNotEmpty($history);
+		$this->assertCount(1, $history);
+
+		$instance = current($result);
+		$attrs = $instance->getAttributes();
+		$this->assertEquals('hello', $attrs[Constants::TYPE_INSTANCE_TITLE_ATTR]);
+		$this->assertEquals('world', $attrs[Constants::TYPE_INSTANCE_DESCRIPTION_ATTR]);
+	}
+}

--- a/plugins/essif-lab/tests/Stubs/ModelManager.php
+++ b/plugins/essif-lab/tests/Stubs/ModelManager.php
@@ -43,6 +43,12 @@ class ModelManager extends BaseModelManager {
 	}
 
 	function selectAllRelations(Model $model): array {
-		return [];
+        return [
+            new ConcreteModel([
+                Constants::TYPE_INSTANCE_IDENTIFIER_ATTR => 1,
+                Constants::TYPE_INSTANCE_TITLE_ATTR => 'hello',
+                Constants::TYPE_INSTANCE_DESCRIPTION_ATTR => 'world',
+            ])
+        ];
 	}
 }

--- a/plugins/essif-lab/tests/Stubs/ModelManager.php
+++ b/plugins/essif-lab/tests/Stubs/ModelManager.php
@@ -2,8 +2,10 @@
 
 namespace TNO\EssifLab\Tests\Stubs;
 
+use TNO\EssifLab\Constants;
 use TNO\EssifLab\ModelManagers\Contracts\BaseModelManager;
 use TNO\EssifLab\Models\Contracts\Model;
+use TNO\EssifLab\Tests\Stubs\Model as ConcreteModel;
 
 class ModelManager extends BaseModelManager {
 	function insert(Model $model): bool {
@@ -19,7 +21,13 @@ class ModelManager extends BaseModelManager {
 	}
 
 	function select(Model $model, array $criteria = []): array {
-		return [];
+		return [
+			new ConcreteModel([
+				Constants::TYPE_INSTANCE_IDENTIFIER_ATTR => 1,
+				Constants::TYPE_INSTANCE_TITLE_ATTR => 'hello',
+				Constants::TYPE_INSTANCE_DESCRIPTION_ATTR => 'world',
+			])
+		];
 	}
 
 	function insertRelation(Model $from, Model $to): bool {

--- a/plugins/essif-lab/tests/Stubs/ModelRenderer.php
+++ b/plugins/essif-lab/tests/Stubs/ModelRenderer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace TNO\EssifLab\Tests\Stubs;
+
+use TNO\EssifLab\Integrations\Contracts\Integration;
+use TNO\EssifLab\Models\Contracts\Model;
+
+class ModelRenderer implements \TNO\EssifLab\ModelRenderers\Contracts\ModelRenderer {
+	private $renderListAndFormViewCalled = false;
+
+ 	private $attrsParamWhereRenderListAndFormViewWasCalledWith;
+
+	function renderListAndFormView(Integration $integration, Model $model, array $attrs = []): string {
+		$this->renderListAndFormViewCalled = true;
+
+		$this->attrsParamWhereRenderListAndFormViewWasCalledWith = $attrs;
+
+		return '';
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isRenderListAndFormViewCalled(): bool {
+		return $this->renderListAndFormViewCalled;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getAttrsParamWhereRenderListAndFormViewWasCalledWith() {
+		return $this->attrsParamWhereRenderListAndFormViewWasCalledWith;
+	}
+}

--- a/plugins/essif-lab/tests/Stubs/Utility.php
+++ b/plugins/essif-lab/tests/Stubs/Utility.php
@@ -3,11 +3,22 @@
 namespace TNO\EssifLab\Tests\Stubs;
 
 use TNO\EssifLab\Utilities\Contracts\BaseUtility;
+use TNO\EssifLab\Utilities\WordPress;
 
 class Utility extends BaseUtility {
 	private $history = [];
 
+	protected $exceptionalFunctions = [
+		WordPress::ADD_ACTION => [self::class, 'addHook'],
+		WordPress::ADD_FILTER => [self::class, 'addHook'],
+	];
+
 	function call(string $name, ...$parameters) {
+		if (array_key_exists($name, $this->exceptionalFunctions)) {
+			$callback = $this->exceptionalFunctions[$name];
+			$callback(...$parameters);
+		}
+
 		$wasCalled = count($this->getHistoryByFuncName($name));
 		$this->history[] = new History($name, $parameters, $wasCalled + 1);
 	}
@@ -20,5 +31,10 @@ class Utility extends BaseUtility {
 		return array_filter($this->history, function (History $history) use ($funcName) {
 			return $history->getFuncName() === $funcName;
 		});
+	}
+
+	static function addHook(string $hook, callable $callback, int $priority = 10, int $accepted_args = 1): void {
+		$params = range(0, $accepted_args);
+		$callback(...$params);
 	}
 }

--- a/plugins/essif-lab/tests/Stubs/Utility.php
+++ b/plugins/essif-lab/tests/Stubs/Utility.php
@@ -11,6 +11,7 @@ class Utility extends BaseUtility {
 	protected $exceptionalFunctions = [
 		WordPress::ADD_ACTION => [self::class, 'addHook'],
 		WordPress::ADD_FILTER => [self::class, 'addHook'],
+		WordPress::ADD_META_BOX => [self::class, 'addMetaBox'],
 	];
 
 	function call(string $name, ...$parameters) {
@@ -36,5 +37,9 @@ class Utility extends BaseUtility {
 	static function addHook(string $hook, callable $callback, int $priority = 10, int $accepted_args = 1): void {
 		$params = range(0, $accepted_args);
 		$callback(...$params);
+	}
+
+	static function addMetaBox($id, $title, $callback, $screen) {
+		$callback();
 	}
 }

--- a/plugins/essif-lab/tests/Stubs/Utility.php
+++ b/plugins/essif-lab/tests/Stubs/Utility.php
@@ -2,26 +2,39 @@
 
 namespace TNO\EssifLab\Tests\Stubs;
 
+use TNO\EssifLab\Constants;
 use TNO\EssifLab\Utilities\Contracts\BaseUtility;
 use TNO\EssifLab\Utilities\WordPress;
 
 class Utility extends BaseUtility {
 	private $history = [];
 
-	protected $exceptionalFunctions = [
+	protected $callbackTriggeringFunctions = [
 		WordPress::ADD_ACTION => [self::class, 'addHook'],
 		WordPress::ADD_FILTER => [self::class, 'addHook'],
 		WordPress::ADD_META_BOX => [self::class, 'addMetaBox'],
 	];
 
+	protected $valueReturningFunctions = [
+		BaseUtility::GET_CURRENT_MODEL => [self::class, 'getCurrentModel'],
+		BaseUtility::GET_MODEL_META => [self::class, 'getModelMeta'],
+		BaseUtility::GET_MODELS => [self::class, 'getModels']
+	];
+
 	function call(string $name, ...$parameters) {
-		if (array_key_exists($name, $this->exceptionalFunctions)) {
-			$callback = $this->exceptionalFunctions[$name];
+		$wasCalled = count($this->getHistoryByFuncName($name));
+		$this->history[] = new History($name, $parameters, $wasCalled + 1);
+
+		if (array_key_exists($name, $this->callbackTriggeringFunctions)) {
+			$callback = $this->callbackTriggeringFunctions[$name];
 			$callback(...$parameters);
 		}
 
-		$wasCalled = count($this->getHistoryByFuncName($name));
-		$this->history[] = new History($name, $parameters, $wasCalled + 1);
+		if (array_key_exists($name, $this->valueReturningFunctions)) {
+			$callback = $this->valueReturningFunctions[$name];
+			return $callback(...$parameters);
+		}
+		return null;
 	}
 
 	/**
@@ -41,5 +54,26 @@ class Utility extends BaseUtility {
 
 	static function addMetaBox($id, $title, $callback, $screen) {
 		$callback();
+	}
+
+	static function getCurrentModel(): array {
+		return [
+			Constants::TYPE_INSTANCE_IDENTIFIER_ATTR => 1,
+			Constants::MANAGER_TYPE_ID_CRITERIA_NAME => 'model'
+		];
+	}
+
+	static function getModelMeta(): array {
+		return [1];
+	}
+
+	static function getModels(): array {
+		return [
+			new Model([
+				Constants::TYPE_INSTANCE_IDENTIFIER_ATTR => 1,
+				Constants::TYPE_INSTANCE_TITLE_ATTR => 'hello',
+				Constants::TYPE_INSTANCE_DESCRIPTION_ATTR => 'world',
+			])
+		];
 	}
 }

--- a/plugins/essif-lab/tests/TestCase.php
+++ b/plugins/essif-lab/tests/TestCase.php
@@ -8,6 +8,7 @@ use TNO\EssifLab\Tests\Stubs\Application;
 use TNO\EssifLab\Tests\Stubs\Integration;
 use TNO\EssifLab\Tests\Stubs\Model;
 use TNO\EssifLab\Tests\Stubs\ModelManager;
+use TNO\EssifLab\Tests\Stubs\ModelRenderer;
 use TNO\EssifLab\Tests\Stubs\Utility;
 
 abstract class TestCase extends PHPUnitTestCase {
@@ -24,6 +25,8 @@ abstract class TestCase extends PHPUnitTestCase {
 
 	protected $model;
 
+	protected $renderer;
+
 	protected function setUp(): void {
 		parent::setUp();
 		if (! defined('ABSPATH')) {
@@ -31,8 +34,9 @@ abstract class TestCase extends PHPUnitTestCase {
 		};
 		$this->application = new Application('name', 'namespace', __DIR__);
 		$this->utility = new Utility();
+		$this->renderer = new ModelRenderer();
 		$this->manager = new ModelManager($this->application, $this->utility);
-		$this->integration = new Integration($this->application, $this->manager, $this->utility);
+		$this->integration = new Integration($this->application, $this->manager, $this->renderer, $this->utility);
 		$this->model = new Model([
 			Constants::TYPE_INSTANCE_TITLE_ATTR => 'hello',
 			Constants::TYPE_INSTANCE_DESCRIPTION_ATTR => 'world',

--- a/plugins/essif-lab/tests/Views/ListItemFormTest.php
+++ b/plugins/essif-lab/tests/Views/ListItemFormTest.php
@@ -5,6 +5,7 @@ namespace TNO\EssifLab\Tests\Views;
 use TNO\EssifLab\Tests\Stubs\ItemDisplayable;
 use TNO\EssifLab\Tests\Stubs\ItemNonDisplayable;
 use TNO\EssifLab\Tests\TestCase;
+use TNO\EssifLab\Utilities\Contracts\BaseUtility;
 use TNO\EssifLab\Views\ListItemForm;
 
 class ListItemFormTest extends TestCase {
@@ -79,10 +80,17 @@ class ListItemFormTest extends TestCase {
 
 		$expected = [
 			'/.*<button.*value="hello".*>'.ListItemForm::REMOVE.'<\/button>.*/',
-			'/.*<a.*href=".*hello.*".*>'.ListItemForm::EDIT.'<\/a>.*/'
+			'/.*<a.*>'.ListItemForm::EDIT.'<\/a>.*/'
 		];
 
 		$this->assertRegExp($expected[0], $actual);
 		$this->assertRegExp($expected[1], $actual);
+
+		$history = $this->utility->getHistoryByFuncName(BaseUtility::GET_EDIT_MODEL_LINK);
+		$this->assertCount(1, $history);
+
+		$entry = current($history);
+		$params = $entry->getParams();
+		$this->assertEquals('hello', $params[0]);
 	}
 }

--- a/plugins/essif-lab/wordpress-plugin.php
+++ b/plugins/essif-lab/wordpress-plugin.php
@@ -15,12 +15,14 @@ require plugin_dir_path(__FILE__).'vendor/autoload.php';
 
 use TNO\EssifLab\Applications\Contracts\Application;
 use TNO\EssifLab\Applications\Plugin;
-use TNO\EssifLab\Utilities\Contracts\Utility;
-use TNO\EssifLab\Utilities\WordPress as WP;
-use TNO\EssifLab\ModelManagers\Contracts\ModelManager;
-use TNO\EssifLab\ModelManagers\WordPressPostTypes;
 use TNO\EssifLab\Integrations\Contracts\Integration;
 use TNO\EssifLab\Integrations\WordPress;
+use TNO\EssifLab\ModelManagers\Contracts\ModelManager;
+use TNO\EssifLab\ModelManagers\WordPressPostTypes;
+use TNO\EssifLab\ModelRenderers\Contracts\ModelRenderer;
+use TNO\EssifLab\ModelRenderers\WordPressMetaBox;
+use TNO\EssifLab\Utilities\Contracts\Utility;
+use TNO\EssifLab\Utilities\WordPress as WP;
 
 // Make sure the WP Plugin API is loaded
 if (! function_exists('get_plugin_data')) {
@@ -45,16 +47,24 @@ $getApplication = function (): Application {
 	return new Plugin($name(), $namespace(), $appDir());
 };
 
-$getUtilities = function (): Utility {
+$getUtility = function (): Utility {
 	return new WP();
 };
 
-$getModelManager = function (Application $application) use ($getUtilities): ModelManager {
-	return new WordPressPostTypes($application, $getUtilities());
+$getModelRenderer = function (): ModelRenderer {
+	return new WordPressMetaBox();
 };
 
-$getIntegration = function (Application $application) use ($getModelManager, $getUtilities): Integration {
-	return new WordPress($application, $getModelManager($application), $getUtilities());
+$getModelManager = function (Application $application) use ($getUtility): ModelManager {
+	return new WordPressPostTypes($application, $getUtility());
+};
+
+$getIntegration = function (Application $application) use (
+	$getModelManager,
+	$getModelRenderer,
+	$getUtility
+): Integration {
+	return new WordPress($application, $getModelManager($application), $getModelRenderer(), $getUtility());
 };
 
 // Install the integration


### PR DESCRIPTION
Deze PR bevat nog niet alle AC punten, zie hieronder. Maar het bevat wel een nieuw contract namelijk het `ModelRenderer` contract wat kan worden ingezet om alle "fields" van een Model te renderen.

**Acceptatie Criteria**

- [x] Verschillende GUI componenten zijn aangemaakt om het veld mee samen te stellen. Namelijk een Form en Lijst component (met bijbehoorende subcomponenten).
- [x] In het formulier worden alle entiteiten van het gerelateerde model type in de select lijst in geladen als er überhaupt entiteiten zijn.
- [x] Na het toevoegen van een entiteit als relatie wordt het item getoond in de lijst weergave.
- [ ] Voor een bestaande relatie wordt bij het lijst item een delete button getoond.